### PR TITLE
Enable even_odd_versions in bot configuration

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,3 +11,6 @@ provider:
   linux_ppc64le: azure
   osx_arm64: azure
 test: native_and_emulated
+bot:
+  version_updates:
+    even_odd_versions: true


### PR DESCRIPTION
This PR enables the `even_odd_versions` setting in the bot section of conda-forge.yml to prevent automated updates to unstable versions.